### PR TITLE
Tiled does not support properties with same name

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ Now, add 2 properties to the variable:
 - `openLayer`: this will contain the name of the layer that has the opened door
 - `closeLayer`: this will contain the name of the layer that has the closed door
 
+Note: for both `openLayer` and `closeLayer`, you can input several layer names separated by a new line character.
+
 Whenever the value of the variable switches from true to false (or the opposite), the door will open or close.
 
 #### Door sound

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@semantic-release/git": "^9.0.0",
         "@semantic-release/npm": "^7.1.0",
         "@tsconfig/svelte": "^1.0.10",
+        "@types/copy-webpack-plugin": "^8.0.1",
         "@types/jest": "^26.0.22",
         "@types/mini-css-extract-plugin": "^1.4.3",
         "@types/webpack-dev-server": "^3.11.4",
@@ -1888,6 +1889,17 @@
       "dependencies": {
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/copy-webpack-plugin": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@types/copy-webpack-plugin/-/copy-webpack-plugin-8.0.1.tgz",
+      "integrity": "sha512-TwEeGse0/wq+t3SFW0DEwroMS/cDkwVZT+vj7tMAYTp7llt/yz6NuW2n04X2M5P/kSfBQOORhrHAN2mqZdmybg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "tapable": "^2.0.0",
+        "webpack": "^5.1.0"
       }
     },
     "node_modules/@types/eslint": {
@@ -20784,6 +20796,17 @@
       "requires": {
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
+      }
+    },
+    "@types/copy-webpack-plugin": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@types/copy-webpack-plugin/-/copy-webpack-plugin-8.0.1.tgz",
+      "integrity": "sha512-TwEeGse0/wq+t3SFW0DEwroMS/cDkwVZT+vj7tMAYTp7llt/yz6NuW2n04X2M5P/kSfBQOORhrHAN2mqZdmybg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "tapable": "^2.0.0",
+        "webpack": "^5.1.0"
       }
     },
     "@types/eslint": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@semantic-release/git": "^9.0.0",
     "@semantic-release/npm": "^7.1.0",
     "@tsconfig/svelte": "^1.0.10",
+    "@types/copy-webpack-plugin": "^8.0.1",
     "@types/jest": "^26.0.22",
     "@types/mini-css-extract-plugin": "^1.4.3",
     "@types/webpack-dev-server": "^3.11.4",

--- a/src/Features/doors.ts
+++ b/src/Features/doors.ts
@@ -17,34 +17,34 @@ let playerY = 0;
  */
 function updateDoorLayers(variable: VariableDescriptor): void {
     if (WA.state[variable.name]) {
-        let layers = variable.properties.getMany("openLayer");
-        for (const layer of layers) {
-            WA.room.showLayer(layer as string);
+        let layers = variable.properties.mustGetString("openLayer");
+        for (const layer of layers.split("\n")) {
+            WA.room.showLayer(layer);
         }
 
-        layers = variable.properties.getMany("closeLayer");
-        for (const layer of layers) {
-            WA.room.hideLayer(layer as string);
+        layers = variable.properties.mustGetString("closeLayer");
+        for (const layer of layers.split("\n")) {
+            WA.room.hideLayer(layer);
         }
     } else {
-        let layers = variable.properties.getMany("openLayer");
-        for (const layer of layers) {
-            WA.room.hideLayer(layer as string);
+        let layers = variable.properties.mustGetString("openLayer");
+        for (const layer of layers.split("\n")) {
+            WA.room.hideLayer(layer);
         }
 
-        layers = variable.properties.getMany("closeLayer");
-        for (const layer of layers) {
-            WA.room.showLayer(layer as string);
+        layers = variable.properties.mustGetString("closeLayer");
+        for (const layer of layers.split("\n")) {
+            WA.room.showLayer(layer);
         }
     }
 }
 
 function playOpenSound(variable: VariableDescriptor): void {
-    const url = variable.properties.getOneString("openSound");
-    const radius = variable.properties.getOneNumber("soundRadius");
+    const url = variable.properties.getString("openSound");
+    const radius = variable.properties.getNumber("soundRadius");
     let volume = 1;
     if (radius) {
-        const distance = getDistance(variable.properties.getMany("openLayer") as string[]);
+        const distance = getDistance(variable.properties.mustGetString("openLayer").split("\n"));
         if (distance > radius) {
             return;
         }
@@ -59,11 +59,11 @@ function playOpenSound(variable: VariableDescriptor): void {
 }
 
 function playCloseSound(variable: VariableDescriptor): void {
-    const url = variable.properties.getOneString("closeSound");
-    const radius = variable.properties.getOneNumber("soundRadius");
+    const url = variable.properties.getString("closeSound");
+    const radius = variable.properties.getNumber("soundRadius");
     let volume = 1;
     if (radius) {
-        const distance = getDistance(variable.properties.getMany("closeLayer") as string[]);
+        const distance = getDistance(variable.properties.mustGetString("closeLayer").split("\n"));
         if (distance > radius) {
             return;
         }
@@ -114,12 +114,12 @@ function initDoorstep(
     let keypadWebsite: EmbeddedWebsite | undefined = undefined;
     let inZone = false;
 
-    const zoneName = properties.getOneString("zone");
+    const zoneName = properties.getString("zone");
     if (!zoneName) {
         throw new Error('Missing "zone" property on doorstep layer "' + name + '"');
     }
 
-    const tag = properties.getOneString("tag");
+    const tag = properties.getString("tag");
     let allowed = true;
     if (tag && !WA.player.tags.includes(tag)) {
         allowed = false;
@@ -132,8 +132,7 @@ function initDoorstep(
         }
 
         actionMessage = WA.ui.displayActionMessage({
-            message:
-                properties.getOneString("closeTriggerMessage") ?? "Press SPACE to close the door",
+            message: properties.getString("closeTriggerMessage") ?? "Press SPACE to close the door",
             callback: () => {
                 WA.state[doorVariable] = false;
                 displayOpenDoorMessage();
@@ -146,8 +145,7 @@ function initDoorstep(
             actionMessage.remove();
         }
         actionMessage = WA.ui.displayActionMessage({
-            message:
-                properties.getOneString("openTriggerMessage") ?? "Press SPACE to open the door",
+            message: properties.getString("openTriggerMessage") ?? "Press SPACE to open the door",
             callback: () => {
                 WA.state[doorVariable] = true;
                 displayCloseDoorMessage();
@@ -180,7 +178,7 @@ function initDoorstep(
 
     WA.room.onEnterZone(zoneName, () => {
         inZone = true;
-        if (properties.getOneBoolean("autoOpen") && allowed) {
+        if (properties.getBoolean("autoOpen") && allowed) {
             WA.state[doorVariable] = true;
             return;
         }
@@ -188,7 +186,7 @@ function initDoorstep(
         if (
             !WA.state[doorVariable] &&
             ((accessRestricted && !allowed) || !accessRestricted) && // Do not display code if user is allowed by tag
-            (properties.getOneString("code") || properties.getOneString("codeVariable"))
+            (properties.getString("code") || properties.getString("codeVariable"))
         ) {
             openKeypad(name);
             return;
@@ -207,7 +205,7 @@ function initDoorstep(
 
     WA.room.onLeaveZone(zoneName, () => {
         inZone = false;
-        if (properties.getOneBoolean("autoClose")) {
+        if (properties.getBoolean("autoClose")) {
             WA.state[doorVariable] = false;
         }
 
@@ -219,7 +217,7 @@ function initDoorstep(
 
     WA.state.onVariableChange(doorVariable).subscribe(() => {
         if (inZone) {
-            if (!properties.getOneBoolean("autoClose") && WA.state[doorVariable] === true) {
+            if (!properties.getBoolean("autoClose") && WA.state[doorVariable] === true) {
                 displayCloseDoorMessage();
             }
 
@@ -227,7 +225,7 @@ function initDoorstep(
                 closeKeypad();
             }
 
-            if (!properties.getOneBoolean("autoOpen") && WA.state[doorVariable] === false) {
+            if (!properties.getBoolean("autoOpen") && WA.state[doorVariable] === false) {
                 displayOpenDoorMessage();
             }
         }
@@ -235,8 +233,8 @@ function initDoorstep(
 }
 
 function playBellSound(variable: VariableDescriptor): void {
-    const url = variable.properties.mustGetOneString("bellSound");
-    const radius = variable.properties.getOneNumber("soundRadius");
+    const url = variable.properties.mustGetString("bellSound");
+    const radius = variable.properties.getNumber("soundRadius");
     let volume = 1;
     if (radius) {
         const distance = Math.sqrt(
@@ -268,9 +266,9 @@ function initBell(variable: VariableDescriptor): void {
 function initBellLayer(bellVariable: string, properties: Properties): void {
     let popup: Popup | undefined = undefined;
 
-    const zoneName = properties.mustGetOneString("zone");
+    const zoneName = properties.mustGetString("zone");
 
-    const bellPopupName = properties.getOneString("bellPopup");
+    const bellPopupName = properties.getString("bellPopup");
 
     WA.room.onEnterZone(zoneName, () => {
         if (!bellPopupName) {
@@ -278,7 +276,7 @@ function initBellLayer(bellVariable: string, properties: Properties): void {
         } else {
             popup = WA.ui.openPopup(bellPopupName, "", [
                 {
-                    label: properties.getOneString("bellButtonText") ?? "Ring",
+                    label: properties.getString("bellButtonText") ?? "Ring",
                     callback: () => {
                         WA.state[bellVariable] = (WA.state[bellVariable] as number) + 1;
                     },
@@ -300,22 +298,22 @@ export async function initDoors(): Promise<void> {
     layersMap = await getLayersMap();
 
     for (const variable of variables.values()) {
-        if (variable.properties.getOne("door")) {
+        if (variable.properties.get("door")) {
             initDoor(variable);
         }
 
-        if (variable.properties.getOne("bell")) {
+        if (variable.properties.get("bell")) {
             initBell(variable);
         }
     }
 
     for (const layer of layersMap.values()) {
         const properties = new Properties(layer.properties);
-        const doorVariable = properties.getOneString("doorVariable");
+        const doorVariable = properties.getString("doorVariable");
         if (doorVariable && layer.type === "tilelayer") {
             initDoorstep(layer, doorVariable, properties);
         }
-        const bellVariable = properties.getOneString("bellVariable");
+        const bellVariable = properties.getString("bellVariable");
         if (bellVariable) {
             initBellLayer(bellVariable, properties);
         }

--- a/src/Features/variable_actions.ts
+++ b/src/Features/variable_actions.ts
@@ -6,18 +6,18 @@ export async function initVariableActions(): Promise<void> {
 
     for (const layer of layers.values()) {
         const properties = new Properties(layer.properties);
-        const variableName = properties.getOneString("bindVariable");
+        const variableName = properties.getString("bindVariable");
         if (variableName) {
-            const zone = properties.getOneString("zone");
+            const zone = properties.getString("zone");
             if (!zone) {
                 throw new Error(
                     'A layer with a "bindVariable" property must ALSO have a "zone" property.',
                 );
             }
-            const enterValue = properties.getOne("enterValue");
-            const leaveValue = properties.getOne("leaveValue");
-            const triggerMessage = properties.getOneString("triggerMessage");
-            const tag = properties.getOneString("tag");
+            const enterValue = properties.get("enterValue");
+            const leaveValue = properties.get("leaveValue");
+            const triggerMessage = properties.getString("triggerMessage");
+            const tag = properties.getString("tag");
 
             initVariableActionLayer(
                 variableName,

--- a/src/Iframes/Keypad/index.ts
+++ b/src/Iframes/Keypad/index.ts
@@ -24,8 +24,8 @@ WA.onInit().then(async () => {
     }
 
     const properties = new Properties(layer.properties);
-    const tmpCode = properties.getOneString("code");
-    const codeVariable = properties.getOneString("codeVariable");
+    const tmpCode = properties.getString("code");
+    const codeVariable = properties.getString("codeVariable");
 
     if (tmpCode === undefined && codeVariable === undefined) {
         throw new Error('Missing "code" or "codeVariable" for layer "' + layerName + '".');
@@ -40,7 +40,7 @@ WA.onInit().then(async () => {
         code = tmpCode as string;
     }
 
-    const doorVariableVal = properties.getOneString("doorVariable");
+    const doorVariableVal = properties.getString("doorVariable");
 
     if (doorVariableVal === undefined) {
         throw new Error('Missing "doorVariable" for layer "' + layerName + '".');

--- a/src/Properties.ts
+++ b/src/Properties.ts
@@ -7,14 +7,10 @@ export class Properties {
         this.properties = properties ?? [];
     }
 
-    public getMany(name: string): (string | boolean | number | undefined)[] {
-        return this.properties
+    public get(name: string): string | boolean | number | undefined {
+        const values = this.properties
             .filter((property) => property.name === name)
             .map((property) => property.value);
-    }
-
-    public getOne(name: string): string | boolean | number | undefined {
-        const values = this.getMany(name);
         if (values.length > 1) {
             throw new Error('Expected only one property to be named "' + name + '"');
         }
@@ -24,23 +20,23 @@ export class Properties {
         return values[0];
     }
 
-    public getOneString(name: string): string | undefined {
-        return this.getOneByType(name, "string") as string | undefined;
+    public getString(name: string): string | undefined {
+        return this.getByType(name, "string") as string | undefined;
     }
 
-    public getOneNumber(name: string): number | undefined {
-        return this.getOneByType(name, "number") as number | undefined;
+    public getNumber(name: string): number | undefined {
+        return this.getByType(name, "number") as number | undefined;
     }
 
-    public getOneBoolean(name: string): boolean | undefined {
-        return this.getOneByType(name, "boolean") as boolean | undefined;
+    public getBoolean(name: string): boolean | undefined {
+        return this.getByType(name, "boolean") as boolean | undefined;
     }
 
-    private getOneByType(
+    private getByType(
         name: string,
         type: "string" | "number" | "boolean",
     ): string | boolean | number | undefined {
-        const value = this.getOne(name);
+        const value = this.get(name);
         if (value === undefined) {
             return undefined;
         }
@@ -50,23 +46,23 @@ export class Properties {
         return value;
     }
 
-    public mustGetOneString(name: string): string {
-        return this.mustGetOneByType(name, "string") as string;
+    public mustGetString(name: string): string {
+        return this.mustGetByType(name, "string") as string;
     }
 
-    public mustGetOneNumber(name: string): number {
-        return this.mustGetOneByType(name, "number") as number;
+    public mustGetNumber(name: string): number {
+        return this.mustGetByType(name, "number") as number;
     }
 
-    public mustGetOneBoolean(name: string): boolean {
-        return this.mustGetOneByType(name, "boolean") as boolean;
+    public mustGetBoolean(name: string): boolean {
+        return this.mustGetByType(name, "boolean") as boolean;
     }
 
-    private mustGetOneByType(
+    private mustGetByType(
         name: string,
         type: "string" | "number" | "boolean",
     ): string | boolean | number | undefined {
-        const value = this.getOne(name);
+        const value = this.get(name);
         if (value === undefined) {
             throw new Error('Property "' + name + '" is missing');
         }


### PR DESCRIPTION
So it is pointless to support those in this package.
Removes support for properties.getMany
Now, the "openLayer" and "closeLayer" properties accept several layers separated by a carriage return.