### PR TITLE
fix(configuration): fixed path when initializing a configuration panel

### DIFF
--- a/src/Features/configuration.ts
+++ b/src/Features/configuration.ts
@@ -16,7 +16,7 @@ export async function initConfiguration(assetsUrl?: string | undefined): Promise
         if (!tag || WA.player.tags.includes(tag)) {
             WA.ui.registerMenuCommand("Configure the room", () => {
                 assetsUrl = assetsUrl ?? defaultAssetsUrl;
-                WA.nav.openCoWebSite(assetsUrl + "configuration.html", true);
+                WA.nav.openCoWebSite(assetsUrl + "/configuration.html", true);
             });
         }
     }


### PR DESCRIPTION
The configuration panel was not working properly because of a missing slash "/" in the path of the htmlfile.
`distconfiguration.html` is now `dist/configuration.html`.