### PR TITLE
Added openConfig function

### DIFF
--- a/docs/functions-variables.md
+++ b/docs/functions-variables.md
@@ -1,5 +1,5 @@
 {.section-title.accent.text-primary}
-# Variables metadata
+# Variables utility functions
 
 {.alert.alert-info}
 **Important!** To use these functions, you need to [import the "Scripting API Extra"](utils.md#importing-the-utility-functions) library.
@@ -42,4 +42,47 @@ class VariableDescriptor {
     // True if the variable can be written by the current player
     isWritable: boolean
 }
+```
+
+{.section-title.accent.text-primary}
+## Configuration panel
+
+### Opening the local configuration panel
+
+```
+// Signature of the function
+function openConfig(variables?: string[]): void
+```
+
+You can open the local configuration panel inside an iFrame just like you do via the Tiled `openConfig` property.
+This property let you filter which variables you want to display in the configuration page.
+
+Well, you can do exactly that thanks to the `openConfig()` function. Here's how it works:
+
+```typescript
+import {openConfig} from '@workadventure/scripting-api-extra';
+
+// This will open the local configuration panel with all the variables in the Tiled 'configuration' layer.
+openConfig();
+```
+
+### Filtering the local configuration panel
+
+You can filter which variables to display by passing an array of variable names to the function.
+
+```typescript
+import {openConfig} from '@workadventure/scripting-api-extra';
+
+// This will open the local configuration panel with the specified variables in the Tiled 'configuration' layer.
+openConfig(['leftDoorExit']);
+```
+
+Here is a quick example of how you can edit a variable by walking near the object that represents it in your map:
+
+```typescript
+import { openConfig } from '@workadventure/scripting-api-extra';
+
+WA.room.onEnterLayer('leftDoorStep').subscribe(() => {
+    openConfig(['leftDoorExit']);
+});
 ```

--- a/src/Features/configuration.ts
+++ b/src/Features/configuration.ts
@@ -32,13 +32,17 @@ export async function initConfiguration(assetsUrl?: string | undefined): Promise
             const properties = new Properties(layer.properties);
             const openConfigVariables = properties.getString("openConfig");
             if (openConfigVariables && layer.type === "tilelayer") {
-                initLocalConfigurationPanel(openConfigVariables.split(','), layer.name, properties);
+                initLocalConfigurationPanel(openConfigVariables.split(","), layer.name, properties);
             }
         }
     }
 }
 
-function initLocalConfigurationPanel(openConfigVariables: string[], layerName: string, properties: Properties): void {
+function initLocalConfigurationPanel(
+    openConfigVariables: string[],
+    layerName: string,
+    properties: Properties,
+): void {
     let actionMessage: ActionMessage | undefined = undefined;
 
     const tag = properties.getString("openConfigAdminTag");

--- a/src/VariablesExtra.ts
+++ b/src/VariablesExtra.ts
@@ -1,6 +1,6 @@
 import type { ITiledMapLayer, ITiledMapObject } from "@workadventure/tiled-map-type-guard/dist";
 import { Properties } from "./Properties";
-import {defaultAssetsUrl} from "./Features/default_assets_url";
+import { defaultAssetsUrl } from "./Features/default_assets_url";
 
 export class VariableDescriptor {
     public readonly name: string;

--- a/src/VariablesExtra.ts
+++ b/src/VariablesExtra.ts
@@ -1,5 +1,6 @@
 import type { ITiledMapLayer, ITiledMapObject } from "@workadventure/tiled-map-type-guard/dist";
 import { Properties } from "./Properties";
+import {defaultAssetsUrl} from "./Features/default_assets_url";
 
 export class VariableDescriptor {
     public readonly name: string;
@@ -29,6 +30,15 @@ export class VariableDescriptor {
         }
         return WA.player.tags.includes(writableBy);
     }
+}
+
+/**
+ * Opens the local configuration panel.
+ * You can filter which variables to configure by passing their names in parameter.
+ */
+export function openConfig(variables?: string[]): void {
+    const parameters = variables ? "#" + variables.join() : "";
+    WA.nav.openCoWebSite(defaultAssetsUrl + "/configuration.html" + parameters);
 }
 
 export async function getVariables(


### PR DESCRIPTION
It would be useful to add a openConfig() utility function.
Adding this will let users open the configuration panel (and filter it) when clicking on a button instead of having to do all the setup in Tiled. The setup is done via the script.

This is just two ways of opening the local configuration panel.