### PR TITLE
fix: Fixes error displayed in the console when there is no tutorial property in map

### DIFF
--- a/src/Features/tutorial.ts
+++ b/src/Features/tutorial.ts
@@ -12,7 +12,7 @@ export async function initTutorial(): Promise<void> {
     const tutorialProperty = await map.properties?.find(
         (property: ITiledMapProperty) => property.name === "tutorial",
     );
-    const isTutorialEnabled = tutorialProperty.value ?? false;
+    const isTutorialEnabled = tutorialProperty && tutorialProperty.value;
 
     if (!tutorialDone && isTutorialEnabled) {
         openTutorial(isForMobile);


### PR DESCRIPTION
This PR:
- [X] Fixes the error displayed in the console when there is no tutorial property in the retrieved map